### PR TITLE
Add router_up gauge

### DIFF
--- a/gauges.go
+++ b/gauges.go
@@ -6,6 +6,11 @@ import (
 )
 
 var (
+	routerUpGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: nameSpace,
+		Name:      "router_up",
+		Help:      "Tells whether MySQL Router is up",
+	})
 	routerStatusGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: nameSpace,
 		Name:      "router_status",

--- a/main.go
+++ b/main.go
@@ -132,8 +132,10 @@ func collectMetrics() {
 	router, err := mysqlRouterClient.GetRouterStatus()
 	if err != nil {
 		writeError(err)
+		routerUpGauge.Set(float64(0))
 		return
 	}
+	routerUpGauge.Set(float64(1))
 	routerStatusGauge.WithLabelValues(strconv.Itoa(router.ProcessID), router.ProductEdition, router.TimeStarted.String(), router.Version, router.Hostname)
 
 	// metadata


### PR DESCRIPTION
Useful for alerting when the MySQL Router is down, currently the exporter cannot detect this situation.