### PR TITLE
Reset Gauges Before every metrics collect

### DIFF
--- a/main.go
+++ b/main.go
@@ -174,6 +174,26 @@ func collectMetrics() {
 		writeError(err)
 		return
 	}
+	
+	if args.CollectRouteConnectionsByteFromServer {
+		routeConnectionsByteFromServerGauge.Reset()
+	}
+	if args.CollectRouteConnectionsByteToServer {
+		routeConnectionsByteToServerGauge.Reset()
+	}
+	if args.CollectRouteConnectionsTimeStarted {
+		routeConnectionsTimeStartedGauge.Reset()
+	}
+	if args.CollectRouteConnectionsTimeConnectedToServer {
+		routeConnectionsTimeConnectedToServerGauge.Reset()
+	}
+	if args.CollectRouteConnectionsTimeLastSentToServer {
+		routeConnectionsTimeLastSentToServerGauge.Reset()
+	}
+	if args.CollectRouteConnectionsTimeReceivedFromServer {
+		routeConnectionsTimeLastReceivedFromServerGauge.Reset()
+	}
+
 	for _, route := range routes {
 		routeGauge.WithLabelValues(route.Name)
 


### PR DESCRIPTION
When using mysqlrouter_exporter with an innodbCluster cluster,  for every collecting step, the old router connections are shown and added to the new ones.

Before every collect, the reset of metric gauges is mandatory to show fresh data.